### PR TITLE
use the windows-host-process-containers-base-image for minimal image …

### DIFF
--- a/hostprocess/csi-proxy/Dockerfile.windows
+++ b/hostprocess/csi-proxy/Dockerfile.windows
@@ -1,6 +1,6 @@
-ARG REGISTRY=mcr.microsoft.com/windows
-ARG WINDOWS_BASE_IMAGE=nanoserver
-ARG WINDOWS_VERSION=1809
+ARG REGISTRY=mcr.microsoft.com/oss/kubernetes
+ARG WINDOWS_BASE_IMAGE=windows-host-process-containers-base-image
+ARG WINDOWS_VERSION=v1.0.0
 
 FROM --platform=linux/amd64 golang:1.20 as builder
 ARG CSI_PROXY_VERSION=v1.1.3

--- a/hostprocess/csi-proxy/build.sh
+++ b/hostprocess/csi-proxy/build.sh
@@ -42,30 +42,5 @@ docker buildx create --name img-builder --use --platform windows/amd64
 trap 'docker buildx rm img-builder' EXIT
 
 
-declare -a win_vers=("1809" "ltsc2022")
+docker buildx build --platform windows/amd64 --output=$output -f Dockerfile.windows -t ${repository}/csi-proxy:${version} .
 
-manifest_entries=""
-
-# Build container images with buildx
-for win_ver in "${win_vers[@]}"; do
-  docker buildx build --provenance=false --sbom=false --platform windows/amd64 --output=$output -f Dockerfile.windows --build-arg=WINDOWS_VERSION=$win_ver -t ${repository}/csi-proxy:${version}-$win_ver .
-
-  manifest_entries="$manifest_entries ${repository}/csi-proxy:${version}-$win_ver"
-done
-
-if [[ $push != "1" ]]; then
-  exit
-fi
-
-# Create manifest
-docker manifest create ${repository}/csi-proxy:${version} $manifest_entries
-
-# Annotate manifests
-for win_ver in "${win_vers[@]}"; do
-  os_ver=$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:${win_ver} | grep "os.version" | head -n 1 | awk -F\" '{print $4}')
-  docker manifest annotate --os windows --arch amd64 --os-version $os_ver $repository/csi-proxy:$version $repository/csi-proxy:$version-$win_ver
-done
-
-docker manifest inspect $repository/csi-proxy:$version
-
-docker manifest push ${repository}/csi-proxy:${version}


### PR DESCRIPTION
…size (#329)

* use the windows-host-process-containers-base-image for minimal image size

* Remove all manifest when using host-process base image

**Reason for PR**:
<!-- What does this PR improve or fix? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


